### PR TITLE
Add initialize component for config, auth, etc

### DIFF
--- a/mui-core-types/package.json
+++ b/mui-core-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifoldco/mui-core-types",
-  "version": "0.0.1-next.34",
+  "version": "0.0.1-next.26",
   "private": false,
   "description": "Initialize function for mui-core",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifoldco/mui-core",
-  "version": "0.0.1-test.1",
+  "version": "0.0.1-next.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "files": [
     "dist/"
   ],
-  "version": "0.0.1-test.1",
+  "version": "0.0.1-next.26",
   "description": "Manifold UI Core",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -11,6 +11,11 @@ import { HTMLStencilElement, JSXBase } from '@stencil/core/internal';
 
 export namespace Components {
   interface ConnectedButton {}
+  interface MuiCore {
+    'authToken'?: string;
+    'authType'?: 'manual' | 'oauth';
+    'env'?: 'stage' | 'prod';
+  }
 }
 
 declare global {
@@ -21,16 +26,29 @@ declare global {
     prototype: HTMLConnectedButtonElement;
     new (): HTMLConnectedButtonElement;
   };
+
+  interface HTMLMuiCoreElement extends Components.MuiCore, HTMLStencilElement {}
+  var HTMLMuiCoreElement: {
+    prototype: HTMLMuiCoreElement;
+    new (): HTMLMuiCoreElement;
+  };
   interface HTMLElementTagNameMap {
     'connected-button': HTMLConnectedButtonElement;
+    'mui-core': HTMLMuiCoreElement;
   }
 }
 
 declare namespace LocalJSX {
   interface ConnectedButton {}
+  interface MuiCore {
+    'authToken'?: string;
+    'authType'?: 'manual' | 'oauth';
+    'env'?: 'stage' | 'prod';
+  }
 
   interface IntrinsicElements {
     'connected-button': ConnectedButton;
+    'mui-core': MuiCore;
   }
 }
 
@@ -41,6 +59,7 @@ declare module "@stencil/core" {
   export namespace JSX {
     interface IntrinsicElements {
       'connected-button': LocalJSX.ConnectedButton & JSXBase.HTMLAttributes<HTMLConnectedButtonElement>;
+      'mui-core': LocalJSX.MuiCore & JSXBase.HTMLAttributes<HTMLMuiCoreElement>;
     }
   }
 }

--- a/src/components/mui-core/mui-core.tsx
+++ b/src/components/mui-core/mui-core.tsx
@@ -1,0 +1,19 @@
+import { Component, Prop } from '@stencil/core';
+import { initialize } from '../../core';
+
+@Component({
+  tag: 'mui-core',
+})
+export class ConnectedButton {
+  @Prop() env?: 'stage' | 'prod' = 'prod';
+  @Prop() authToken?: string;
+  @Prop() authType?: 'manual' | 'oauth' = 'oauth';
+
+  componentWillLoad() {
+    initialize({ env: this.env, authToken: this.authToken, authType: this.authType });
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,12 +1,20 @@
 import connection, { InitDetail } from './v0';
 
-const getConnection = (e: CustomEvent<InitDetail>) => {
+interface InitOptions {
+  authType?: 'manual' | 'oauth';
+  env?: 'stage' | 'prod';
+  authToken?: string;
+}
+
+const getConnection = (e: CustomEvent<InitDetail>, options: InitOptions) => {
   const { version } = e.detail;
 
   switch (version) {
     case undefined: // latest
     case 0:
-      return connection(e);
+      return connection(e, {
+        env: options.env,
+      });
     default:
       throw new Error(
         `Version ${version} doesn't exist. Ensure you have the latest release of mui-core.`
@@ -14,12 +22,14 @@ const getConnection = (e: CustomEvent<InitDetail>) => {
   }
 };
 
-const onInitialize = (e: CustomEvent<InitDetail>) => {
+const onInitialize = (options: InitOptions) => (e: CustomEvent<InitDetail>) => {
   try {
-    e.detail.resolve(getConnection(e));
+    e.detail.resolve(getConnection(e, options));
   } catch (error) {
     e.detail.reject(error);
   }
 };
 
-document.addEventListener('mui-initialize', onInitialize);
+export function initialize(options: InitOptions) {
+  document.addEventListener('mui-initialize', onInitialize(options));
+}

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,8 @@
   </head>
   <body>
     <h1>MUI Core</h1>
-    <connected-button></connected-button>
+    <mui-core>
+      <connected-button></connected-button>
+    </mui-core>
   </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import './core';
+export { initialize } from './core';
 
 export * from './components';

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -18,7 +18,7 @@ export interface InitDetail {
   componentVersion: string;
 }
 
-const connection = (e: CustomEvent<InitDetail>) => {
+const connection = (e: CustomEvent<InitDetail>, options: { env: 'stage' | 'prod' }) => {
   const { componentVersion } = e.detail;
   const element = e.target as HTMLElement;
 
@@ -26,6 +26,10 @@ const connection = (e: CustomEvent<InitDetail>) => {
     graphqlFetch: createGraphqlFetch({
       element,
       version: componentVersion,
+      endpoint: () =>
+        options.env === 'stage'
+          ? 'https://api.stage.manifold.co/graphql'
+          : 'https://api.manifold.co/graphql',
     }),
     track,
   };


### PR DESCRIPTION
This exposes an initialize function that allows users to set auth tokens and global configurations. Initialize must now be called before mui-core will start listening for the `mui-initialize` event.

Notes:

- The only init option currently being used is env, we will consume the others when we implement authentication
- We'll also expose a web component that acts as a wrapper around `initialize`, leaving consumers the option to choose what suites their use case
- If the `initialize` funciton is used directly, it should be done before our other web components are rendered
- If the web component is used, all of our other components should be rendered as descendants of the mui-core component, to ensure that mui-core is initialized before the components request a version of the contract.
- I want to make sure this new `initialize` function's type information is being published to our types package, @davidleger95 can you please comment on that?
- In the near future I'd like to create an `examples` folder with examples that could reference the project's mui-core build as a dependency and show various use cases for mui-core. Then we could delete the `connected-button` component in favor for examples that more closely match the different ways that mui-core might be used in the wild.