### PR TITLE
Optional clientId headers

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -17,7 +17,7 @@ export namespace Components {
     'authToken'?: string;
     'authType'?: 'manual' | 'oauth';
     'env'?: 'stage' | 'prod';
-    'initialize': (options: { element: HTMLElement; componentVersion: string; version: number; }) => Promise<Connection>;
+    'initialize': (options: { element: HTMLElement; componentVersion: string; version: number; clientId?: string; }) => Promise<Connection>;
   }
 }
 

--- a/src/components/mui-core/mui-core.tsx
+++ b/src/components/mui-core/mui-core.tsx
@@ -17,8 +17,9 @@ export class MuiCore {
     element: HTMLElement;
     componentVersion: string;
     version: number;
+    clientId?: string;
   }): Promise<Connection> {
-    const { version, componentVersion, element } = options;
+    const { version, componentVersion, element, clientId } = options;
     return core.initialize({
       env: this.env,
       authToken: this.authToken,
@@ -26,6 +27,7 @@ export class MuiCore {
       version,
       componentVersion,
       element,
+      clientId,
     });
   }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,13 +4,14 @@ interface InitOptions {
   authType?: 'manual' | 'oauth';
   env?: 'stage' | 'prod';
   authToken?: string;
+  clientId?: string;
   componentVersion: string;
   version: number;
   element: HTMLElement;
 }
 
 const getConnection = (options: InitOptions) => {
-  const { version, element, env, componentVersion } = options;
+  const { version, element, env, componentVersion, clientId } = options;
 
   switch (version) {
     case undefined: // latest
@@ -19,6 +20,7 @@ const getConnection = (options: InitOptions) => {
         env,
         element,
         componentVersion,
+        clientId,
       });
     default:
       throw new Error(

--- a/src/v0/graphqlFetch.ts
+++ b/src/v0/graphqlFetch.ts
@@ -24,6 +24,7 @@ const findAuthError = (errors: GraphqlError[] = []) =>
 
 interface CreateGraphqlFetch {
   endpoint?: () => string;
+  clientId?: string;
   element: HTMLElement;
   version: string;
   retries?: number;
@@ -60,16 +61,21 @@ export function createGraphqlFetch({
   endpoint = () => 'https://api.manifold.co/graphql',
   version,
   retries = 3,
+  clientId,
 }: CreateGraphqlFetch): GraphqlFetch {
   const options: RequestInit = {
     method: 'POST',
     headers: {
       Connection: 'keep-alive',
       'Content-type': 'application/json',
-      ...(element ? { 'x-mui-component': `${element.tagName}@${version}` } : {}),
+      'x-mui-component': `${element.tagName}@${version}`,
       'x-manifold-mui-core-version': '<@NPM_PACKAGE_VERSION@>',
     },
   };
+
+  if (clientId) {
+    options.headers['Manifold-Client-ID'] = clientId;
+  }
 
   async function graphqlFetch<T>(
     args: GraphqlRequest,

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -15,13 +15,15 @@ const connection = (options: {
   env: 'stage' | 'prod';
   element: HTMLElement;
   componentVersion: string;
+  clientId?: string;
 }): Connection => {
-  const { componentVersion, element, env } = options;
+  const { componentVersion, element, env, clientId } = options;
 
   return {
     graphqlFetch: createGraphqlFetch({
       element,
       version: componentVersion,
+      clientId,
       endpoint: () =>
         env === 'stage'
           ? 'https://api.stage.manifold.co/graphql'


### PR DESCRIPTION
If a component needs to make a request with the clientId, it can now pass the clientId into `initialize`