### PR TITLE
Publish source code to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "dist/",
-    "loader/"
+    "loader/",
+    "src/"
   ],
   "version": "0.0.1-next.26",
   "description": "Manifold UI Core",


### PR DESCRIPTION
Having the source code available on npm will make it easier for us to write tests in our WC libraries that use mui-core.

We don't need them on the CDN at all, just having them on npm will suffice.